### PR TITLE
fix: error when github server is down

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -58,14 +58,20 @@ module.exports = function server () {
   }
 
   function buildMessage (data) {
+    if (!data) {
+      return Promise.resolve(
+        ':rotating_light: Could not fetch pull requests...'
+      )
+    }
+
     if (data.length < 1) {
       return Promise.resolve(
-        ':oncoming_police_car: No pull requests are waiting for review! :tada:'
+        ':cop: No pull requests are waiting for review! :tada:'
       )
     }
 
     const headers = [
-      ':police_car: The following pull requests are waiting for a review:',
+      ':cop: The following pull requests are waiting for a review:',
       '\n'
     ]
 


### PR DESCRIPTION
When github is down, pr-police throws an error because it's expecting
the value data to be an array (calling .length on it).

This commit adds a check to see if data exists, if it doesn't returns
immediatly with a message stating that it could not fetch the issues, so
that users are warned correctly.