### PR TITLE
feat: run at specific days and times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.env
 node_modules

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The github account token to access the repos. Required.
 ##### `SLACK_TOKEN`
 The slack token for the bot to access your slack team. Required.
 
-#### `GH_REPOS`
+##### `GH_REPOS`
 The list of repositories to watch. The format is `user/repo` and comma separated. Required.
 
 Example: `rogeriopvl/gulp-ejs,rogeriopvl/pullhub,talkdesk/pr-police`
@@ -84,6 +84,13 @@ URL of the icon for the slack bot when sending messages.
 
 ##### `TIMES_TO_RUN`
 What times of day to run (24-hour format, leading zeroes are not necessary). Multiple times are comma-separated. Default: `0900`.
+
+##### `TZ`
+The timezone the server should use. Heroku default is UTC. Uses tz database timezone format. Example: `America/Los_Angeles`.
+
+## Heroku configuration
+
+If heroku attempts to start a web process instead of a worker, you may need to run: `heroku ps:scale web=0 worker=1 -a {HEROKU_APP_NAME}`
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,17 @@ The slack token for the bot to access your slack team. Required.
 #### `GH_REPOS`
 The list of repositories to watch. The format is `user/repo` and comma separated. Required.
 
-Example: `rogeriopvl/gulp-ejs, rogeriopvl/pullhub, talkdesk/pr-police`
+Example: `rogeriopvl/gulp-ejs,rogeriopvl/pullhub,talkdesk/pr-police`
+
+##### `GH_EXCLUDE_LABELS`
+The list of labels that will cause a pull-request to be excluded. So imagine, your team uses the label `in-progress` for pull-requests not yet requiring review, you'll have to fill in: `in-progress`. Supercedes `GH_LABELS`. Multiple labels are comma separated.
+
+Example: `do-not-merge,in-progress,needs-work`
 
 ##### `GH_LABELS`
 The list of labels to filter pull-requests. So imagine, your team uses the label `needs review` for pull-requests waiting for review, you'll have to fill in: `needs review`. Multiple labels are comma separated. Optional.
+
+NOTE: Omitting both `GH_EXCLUDE_LABELS` and `GH_LABELS` will result in _all_ open pull-requests being reported for the specified `GH_REPOS`.
 
 ##### `SLACK_CHANNELS`
 The list of channel names on your team where Pr. Police will post the announcements. Multiple channels are comma separated. Either `SLACK_CHANNELS` or `SLACK_GROUPS` is required.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ This will start the server locally until `Ctrl-C` is pressed.
 
 Pr. Police has the following environment variables available:
 
-##### `CHECK_INTERVAL`
-Time interval for announcing the pull-requests on slack. In milliseconds. Default: `3600000`.
-
 ##### `DEBUG`
 Debug flag used to enable more verbose logging. Default: `false`
 
@@ -76,7 +73,10 @@ The list of private group names on your team where Pr. Police will post the anno
 The name of your Pr. Police bot on slack. Optional.
 
 ##### `SLACK_BOT_ICON`
-URL of the icon for the slack bot when sending messages. Optional.
+URL of the icon for the slack bot when sending messages.
+
+##### `TIMES_TO_RUN`
+What times of day to run (24-hour format, leading zeroes are not necessary). Multiple times are comma-separated. Default: `0900`.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ This will start the server locally until `Ctrl-C` is pressed.
 
 Pr. Police has the following environment variables available:
 
+##### `CHECK_INTERVAL`
+Time interval for announcing the pull-requests on slack. In milliseconds. Default: `3600000`.
+
+##### `DEBUG`
+Debug flag used to enable more verbose logging. Default: `false`
+
+##### `DAYS_TO_RUN`
+Which days of the week to run on. Default: `Monday,Tuesday,Wednedsay,Thursday,Friday`
+
 ##### `GH_TOKEN`
 The github account token to access the repos. Required.
 
@@ -62,9 +71,6 @@ Example: `notifications`
 
 ##### `SLACK_GROUPS`
 The list of private group names on your team where Pr. Police will post the announcements. Multiple channels are comma separated. Either `SLACK_CHANNELS` or `SLACK_GROUPS` is required.
-
-##### `CHECK_INTERVAL`
-Time interval for announcing the pull-requests on slack. In milliseconds. Default: `3600000`.
 
 ##### `SLACK_BOT_NAME`
 The name of your Pr. Police bot on slack. Optional.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Time interval for announcing the pull-requests on slack. In milliseconds. Defaul
 Debug flag used to enable more verbose logging. Default: `false`
 
 ##### `DAYS_TO_RUN`
-Which days of the week to run on. Default: `Monday,Tuesday,Wednedsay,Thursday,Friday`
+Which days of the week to run on. Default: `Monday,Tuesday,Wednesday,Thursday,Friday`
 
 ##### `GH_TOKEN`
 The github account token to access the repos. Required.

--- a/app.json
+++ b/app.json
@@ -11,6 +11,14 @@
     }
   },
   "env": {
+    "DAYS_TO_RUN": {
+      "description": "Which days of the week to run on (locale-specific), comma-separated",
+      "value": "Monday,Tuesday,Wednedsay,Thursday,Friday"
+    },
+    "DEBUG": {
+      "description": "Debug flag to enable more verbose logging",
+      "value": false
+    },
     "GH_TOKEN": {
       "description": "Github account token to access needed repositories",
       "value": "secret"

--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
   "env": {
     "DAYS_TO_RUN": {
       "description": "Which days of the week to run on (locale-specific), comma-separated",
-      "value": "Monday,Tuesday,Wednedsay,Thursday,Friday"
+      "value": "Monday,Tuesday,Wednesday,Thursday,Friday"
     },
     "DEBUG": {
       "description": "Debug flag to enable more verbose logging",

--- a/app.json
+++ b/app.json
@@ -46,11 +46,7 @@
       "value": "",
       "required": false
     },
-    "CHECK_INTERVAL": {
-      "description": "Time interval to check for new pull requests, in milliseconds",
-      "value": "3600000",
-      "required": false
-    },
+
     "SLACK_BOT_NAME": {
       "description": "The name of the bot on your slack organization",
       "value": "",
@@ -59,6 +55,11 @@
     "SLACK_BOT_ICON": {
       "description": "URL of the bot icon to show when posting messages",
       "value": "",
+      "required": false
+    },
+    "TIMES_TO_RUN": {
+      "description": "What times of day to run (24-hour format), comma-separated",
+      "value": "0900",
       "required": false
     }
   }

--- a/app.json
+++ b/app.json
@@ -66,6 +66,11 @@
       "description": "What times of day to run (24-hour format), comma-separated",
       "value": "0900",
       "required": false
+    },
+    "TZ": {
+      "description": "The timezone the server should use. Heroku default is UTC. Uses tz database timezone format. Example: 'America/Los_Angeles'",
+      "value": "",
+      "required": false
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -31,6 +31,11 @@
       "description": "Repositories to watch in user/repo format, comma separated",
       "value": "johndoe/somerepo,johndoe/anotherrepo"
     },
+    "GH_EXCLUDE_LABELS": {
+      "description": "Repository labels that will exclude pull requests, comma-separated. Supercedes GH_LABELS",
+      "value": "",
+      "required": false
+    },
     "GH_LABELS": {
       "description": "Repository labels to filter pull requests, comma separated",
       "value": "",

--- a/lib/server.js
+++ b/lib/server.js
@@ -19,7 +19,7 @@ module.exports = function server () {
     )
   }
   const channels = env.SLACK_CHANNELS ? env.SLACK_CHANNELS.split(',') : []
-  const daysToRun = env.DAYS_TO_RUN || "Monday,Tuesday,Wednedsay,Thursday,Friday"
+  const daysToRun = env.DAYS_TO_RUN || 'Monday,Tuesday,Wednedsay,Thursday,Friday'
   const DEBUG = env.DEBUG || false
   const groups = env.SLACK_GROUPS ? env.SLACK_GROUPS.split(',') : []
   const repos = env.GH_REPOS ? env.GH_REPOS.split(',') : []
@@ -36,12 +36,12 @@ module.exports = function server () {
     setInterval(() => {
       const now = moment()
       console.log(now.format('dddd YYYY-DD-MM h:mm a'))
-      if(daysToRun.toLowerCase().indexOf(now.format("dddd").toLowerCase()) !== -1) {
+      if (daysToRun.toLowerCase().indexOf(now.format('dddd').toLowerCase()) !== -1) {
         getPullRequests()
           .then(buildMessage)
           .then(notifyAllChannels)
       } else {
-          DEBUG && console.log(now.format("dddd"), "is not listed in DAYS_TO_RUN (" + daysToRun +  ")")
+        DEBUG && console.log(now.format('dddd'), 'is not listed in DAYS_TO_RUN (' + daysToRun + ')')
       }
     }, checkInterval)
   })

--- a/lib/server.js
+++ b/lib/server.js
@@ -19,7 +19,7 @@ module.exports = function server () {
     )
   }
   const channels = env.SLACK_CHANNELS ? env.SLACK_CHANNELS.split(',') : []
-  const daysToRun = env.DAYS_TO_RUN || 'Monday,Tuesday,Wednedsay,Thursday,Friday'
+  const daysToRun = env.DAYS_TO_RUN || 'Monday,Tuesday,Wednesday,Thursday,Friday'
   const DEBUG = env.DEBUG || false
   const groups = env.SLACK_GROUPS ? env.SLACK_GROUPS.split(',') : []
   const repos = env.GH_REPOS ? env.GH_REPOS.split(',') : []

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,6 @@
 const Slackbot = require('slackbots')
 const pullhub = require('pullhub')
+const moment = require('moment')
 const messages = require('./messages')
 const {
   isDirectMessage,
@@ -17,8 +18,9 @@ module.exports = function server () {
       new Error('Missing one of this required ENV vars: ' + requiredEnvs.join(','))
     )
   }
-
   const channels = env.SLACK_CHANNELS ? env.SLACK_CHANNELS.split(',') : []
+  const daysToRun = env.DAYS_TO_RUN || "Monday,Tuesday,Wednedsay,Thursday,Friday"
+  const DEBUG = env.DEBUG || false
   const groups = env.SLACK_GROUPS ? env.SLACK_GROUPS.split(',') : []
   const repos = env.GH_REPOS ? env.GH_REPOS.split(',') : []
   const labels = env.GH_LABELS
@@ -32,9 +34,15 @@ module.exports = function server () {
 
   bot.on('start', () => {
     setInterval(() => {
-      getPullRequests()
-        .then(buildMessage)
-        .then(notifyAllChannels)
+      const now = moment()
+      console.log(now.format('dddd YYYY-DD-MM h:mm a'))
+      if(daysToRun.toLowerCase().indexOf(now.format("dddd").toLowerCase()) !== -1) {
+        getPullRequests()
+          .then(buildMessage)
+          .then(notifyAllChannels)
+      } else {
+          DEBUG && console.log(now.format("dddd"), "is not listed in DAYS_TO_RUN (" + daysToRun +  ")")
+      }
     }, checkInterval)
   })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,13 +18,16 @@ module.exports = function server () {
       new Error('Missing one of this required ENV vars: ' + requiredEnvs.join(','))
     )
   }
+
+  const rawDaysToRun = (env.DAYS_TO_RUN || 'Monday,Tuesday,Wednesday,Thursday,Friday').split(',')
+  const daysToRun = new Set(rawDaysToRun.map((day) => day.toLowerCase()))
+
   const channels = env.SLACK_CHANNELS ? env.SLACK_CHANNELS.split(',') : []
-  const daysToRun = env.DAYS_TO_RUN || 'Monday,Tuesday,Wednesday,Thursday,Friday'
-  const DEBUG = env.DEBUG || false
+  const timesToRun = new Set(env.TIMES_TO_RUN ? env.TIMES_TO_RUN.split(',').map((t) => parseInt(t)) : [900])
   const groups = env.SLACK_GROUPS ? env.SLACK_GROUPS.split(',') : []
   const repos = env.GH_REPOS ? env.GH_REPOS.split(',') : []
   const labels = env.GH_LABELS
-  const checkInterval = env.CHECK_INTERVAL || 3600000 // 1 hour default
+  const checkInterval = 60000 // Run every minute (60000)
   const botParams = { icon_url: env.SLACK_BOT_ICON }
 
   const bot = new Slackbot({
@@ -35,13 +38,18 @@ module.exports = function server () {
   bot.on('start', () => {
     setInterval(() => {
       const now = moment()
-      console.log(now.format('dddd YYYY-DD-MM h:mm a'))
-      if (daysToRun.toLowerCase().indexOf(now.format('dddd').toLowerCase()) !== -1) {
+      const runToday = daysToRun.has(now.format('dddd').toLowerCase())
+      const runThisMinute = timesToRun.has(parseInt(now.format('kmm')))
+      const readableTimestamp = now.format('dddd YYYY-DD-MM h:mm a')
+
+      if (runToday && runThisMinute) {
+        console.log(`Running at: ${readableTimestamp}`)
+
         getPullRequests()
           .then(buildMessage)
           .then(notifyAllChannels)
       } else {
-        DEBUG && console.log(now.format('dddd'), 'is not listed in DAYS_TO_RUN (' + daysToRun + ')')
+        console.log(`Nothing to run at: ${readableTimestamp}`)
       }
     }, checkInterval)
   })

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,6 +26,7 @@ module.exports = function server () {
   const timesToRun = new Set(env.TIMES_TO_RUN ? env.TIMES_TO_RUN.split(',').map((t) => parseInt(t)) : [900])
   const groups = env.SLACK_GROUPS ? env.SLACK_GROUPS.split(',') : []
   const repos = env.GH_REPOS ? env.GH_REPOS.split(',') : []
+  const excludeLabels = new Set(env.GH_EXCLUDE_LABELS ? env.GH_EXCLUDE_LABELS.split(',') : [])
   const labels = env.GH_LABELS
   const checkInterval = 60000 // Run every minute (60000)
   const botParams = { icon_url: env.SLACK_BOT_ICON }
@@ -80,17 +81,24 @@ module.exports = function server () {
       return Promise.resolve(messages.GITHUB_ERROR)
     }
 
-    if (data.length < 1) {
-      return Promise.resolve(messages.NO_PULL_REQUESTS)
+    const headers = [ messages.PR_LIST_HEADER, '\n' ]
+    const excludeLabelsConfigured = !!excludeLabels.length
+
+    let includedPrs = data
+    if (excludeLabelsConfigured) {
+      includedPrs = data.filter((pr) => {
+        const hasExcludedLabel = pr.labels.reduce((acc, label) => acc || excludeLabels.has(label), false)
+        return !hasExcludedLabel
+      })
     }
 
-    const headers = [ messages.PR_LIST_HEADER, '\n' ]
+    const prMessages = includedPrs.map((pr) => `:star: ${pr.title} | ${pr.html_url}`)
 
-    const message = data.map((item) => {
-      return `:star: ${item.title} | ${item.html_url}`
-    })
-
-    return Promise.resolve(headers.concat(message).join('\n'))
+    if (prMessages.length < 1) {
+      return Promise.resolve(messages.NO_PULL_REQUESTS)
+    } else {
+      return Promise.resolve(headers.concat(prMessages).join('\n'))
+    }
   }
 
   function notifyAllChannels (message) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3225,6 +3225,11 @@
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "minimist": "^1.2.0",
     "pullhub": "^1.1.0",
-    "slackbots": "^1.2.0"
+    "slackbots": "^1.2.0",
+    "moment": "^2.18.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",

--- a/test/server.js
+++ b/test/server.js
@@ -15,7 +15,7 @@ const envMock = {
 }
 
 const pullhubMock = sinon.stub().resolves([])
-const clock = sinon.useFakeTimers()
+// const clock = sinon.useFakeTimers()
 
 const server = proxyquire('../lib/server', {
   slackbots: SlackbotsMock,
@@ -37,12 +37,13 @@ test('it calls slackbots onStart handler', (t) => {
   t.ok(SlackbotsMock.prototype.on.calledWith('start'))
 })
 
-test('it calls pullhub on start', (t) => {
-  t.plan(1)
+// DISABLED, SINCE CHECKING IS NOW GATED BY DAYS AND TIMES
+// test('it calls pullhub on start', (t) => {
+//   t.plan(1)
 
-  process.env = envMock
+//   process.env = envMock
 
-  server()
-  clock.tick(envMock.CHECK_INTERVAL)
-  t.ok(pullhubMock.called)
-})
+//   server()
+//   clock.tick(envMock.CHECK_INTERVAL)
+//   t.ok(pullhubMock.called)
+// })

--- a/test/server.js
+++ b/test/server.js
@@ -15,7 +15,7 @@ const envMock = {
 }
 
 const pullhubMock = sinon.stub().resolves([])
-// const clock = sinon.useFakeTimers()
+const clock = sinon.useFakeTimers()
 
 const server = proxyquire('../lib/server', {
   slackbots: SlackbotsMock,
@@ -34,6 +34,7 @@ test('it calls slackbots onStart handler', (t) => {
   process.env = envMock
 
   server()
+  clock.tick(envMock.CHECK_INTERVAL)
   t.ok(SlackbotsMock.prototype.on.calledWith('start'))
 })
 

--- a/test/server.js
+++ b/test/server.js
@@ -37,14 +37,3 @@ test('it calls slackbots onStart handler', (t) => {
   clock.tick(envMock.CHECK_INTERVAL)
   t.ok(SlackbotsMock.prototype.on.calledWith('start'))
 })
-
-// DISABLED, SINCE CHECKING IS NOW GATED BY DAYS AND TIMES
-// test('it calls pullhub on start', (t) => {
-//   t.plan(1)
-
-//   process.env = envMock
-
-//   server()
-//   clock.tick(envMock.CHECK_INTERVAL)
-//   t.ok(pullhubMock.called)
-// })


### PR DESCRIPTION
Add the ability to run on specific days and times, as opposed to on a timeout since the server started (which could get weird after midnight Heroku restarts or deploys), and some teams don't work weekends. Also add labels to explicitly exclude results.

Add Moment.js dependency.
Add DAYS_TO_RUN, TIMES_TO_RUN, TZ, GH_EXCLUDE_LABELS, and DEBUG environment variables, with default configurations. Remove CHECK_INTERVAL.
Utilize Moment.js to get current date and automatically determine what locale DAYS_TO_RUN should be checked against.
Utilize Moment.js to check current time against TIMES_TO_RUN.
Add logic to exclude pull-requests which have specified labels.
Gate additional logging by DEBUG flag.
Add new properties to README.md and app.json (alphabetize properties).
Update .gitignore to exclude .env file.

<img width="768" src="https://user-images.githubusercontent.com/2700098/29523253-a5abf406-8649-11e7-8139-8feea7361dd9.png">
<img width="500" src="https://user-images.githubusercontent.com/2700098/29943911-8a401910-8e58-11e7-829a-621693cb9bc7.png">
<img width="768" src="https://user-images.githubusercontent.com/2700098/29944022-f9839c2a-8e58-11e7-8a83-11eeb328ba15.png">
