### PR TITLE
fix: configure dyno to be worker insted of web

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,12 @@
   "repository": "https://github.com/Talkdesk/pr-police",
   "keywords": ["pull", "request", "police", "github", "node", "slackbot", "slack"],
   "logo": "https://raw.githubusercontent.com/Talkdesk/pr-police/master/images/badge-white-small.png",
+  "formation": {
+    "worker": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
   "env": {
     "GH_TOKEN": {
       "description": "Github account token to access needed repositories",


### PR DESCRIPTION
By default app.json sets the dyno to be of web type, this causes an
error when heroku attempts to bind the bot PORT.

This commit specifies the dyno to be of worker type to avoid this.

Fixes #7