### PR TITLE
Adds the configuration parsing logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "jsonschema": "^1.2.4",
     "tslib": "^1.9.3"
   }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,162 @@
+import { validate as validateSchema } from 'jsonschema'
+
+enum Weekday {
+  MONDAY = 'mon',
+  TUESDAY = 'tue',
+  WEDNESDAY = 'wed',
+  THURSDAY = 'thu',
+  FRIDAY = 'fri',
+  SATURDAY = 'sat',
+  SUNDAY = 'sun',
+}
+
+class ScheduleConfiguration {
+  constructor(readonly hour: number, readonly minute: number, readonly weekdays: Weekday[]) {}
+}
+
+enum RepositoryHost {
+  GITHUB = 'github',
+}
+
+class RepositoryConfiguration {
+  constructor(readonly host: RepositoryHost, readonly id: string) {}
+}
+
+enum NotificationChannel {
+  SLACK = 'slack',
+}
+
+class NotificationConfiguration {
+  constructor(readonly channel: NotificationChannel, readonly address: string) {}
+}
+
+class ExecutionConfiguration {
+  constructor(
+    readonly schedule: ScheduleConfiguration,
+    readonly repositories: RepositoryConfiguration[],
+    readonly notifications: NotificationConfiguration[]
+  ) {}
+}
+
+class TeamConfiguration {
+  constructor(readonly name: string, readonly executions: ExecutionConfiguration[]) {}
+}
+
+const schema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://github.com/Talkdesk/pr-police/config.schema.json',
+  type: 'object',
+  patternProperties: {
+    '^.*$': { $ref: '#/definitions/team' },
+  },
+  definitions: {
+    team: {
+      type: 'object',
+      required: ['executions'],
+      properties: {
+        executions: {
+          type: 'array',
+          items: { $ref: '#/definitions/execution' },
+        },
+      },
+    },
+    execution: {
+      type: 'object',
+      required: ['schedule', 'repositories', 'notifications'],
+      properties: {
+        schedule: { $ref: '#/definitions/schedule' },
+        repositories: {
+          type: 'array',
+          items: { $ref: '#/definitions/repository' },
+        },
+        notifications: {
+          type: 'array',
+          items: { $ref: '#/definitions/notification' },
+        },
+      },
+    },
+    schedule: {
+      type: 'object',
+      required: ['hour', 'minute', 'weekdays'],
+      properties: {
+        hour: {
+          type: 'integer',
+          minimum: 0,
+          maximum: 23,
+        },
+        minute: {
+          type: 'integer',
+          minimum: 0,
+          maximum: 59,
+        },
+        weekdays: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+          },
+        },
+      },
+    },
+    repository: {
+      type: 'object',
+      required: ['host', 'id'],
+      properties: {
+        host: {
+          type: 'string',
+          enum: ['github'],
+        },
+        id: {
+          type: 'string',
+        },
+      },
+    },
+    notification: {
+      type: 'object',
+      required: ['channel', 'address'],
+      properties: {
+        channel: {
+          type: 'string',
+          enum: ['slack'],
+        },
+        address: {
+          type: 'string',
+        },
+      },
+    },
+  },
+}
+
+export class InvalidConfigurationError extends Error {}
+
+const mapRepository = config => new RepositoryConfiguration(config.host, config.id)
+
+const mapNotification = config => new NotificationConfiguration(config.channel, config.address)
+
+const mapExecution = config => {
+  const repositories = config.repositories.map(mapRepository)
+  const notifications = config.notifications.map(mapNotification)
+  const schedule = new ScheduleConfiguration(
+    config.schedule.hour,
+    config.schedule.minute,
+    config.schedule.weekdays
+  )
+
+  return new ExecutionConfiguration(schedule, repositories, notifications)
+}
+
+const mapTeam = (name, config) => new TeamConfiguration(name, config.executions.map(mapExecution))
+
+export const parse = (config): TeamConfiguration[] => {
+  const validationResult = validateSchema(config, schema)
+
+  if (!validationResult.valid) {
+    const errors = validationResult.errors.map(e => `${e.property}: ${e.message}`).join('\n')
+
+    throw new InvalidConfigurationError(
+      `The configuration doesn't match the expected schema ${errors}`
+    )
+  }
+
+  return Object.entries(config).map(entry => mapTeam(...entry))
+}

--- a/tests/configuration.spec.ts
+++ b/tests/configuration.spec.ts
@@ -1,0 +1,176 @@
+import { InvalidConfigurationError, parse } from '../src/configuration'
+
+describe('parse', () => {
+  it('returns a correctly parsed configuration', () => {
+    const input = {
+      team1: {
+        executions: [
+          {
+            schedule: { hour: 10, minute: 0, weekdays: ['mon', 'wed'] },
+            repositories: [
+              { host: 'github', id: 'talkdesk/team1-repo1' },
+              { host: 'github', id: 'talkdesk/team1-repo2' },
+            ],
+            notifications: [
+              { channel: 'slack', address: '#team1' },
+              { channel: 'slack', address: '#team2' },
+            ],
+          },
+        ],
+      },
+    }
+
+    const config = parse(input)
+
+    expect(Object.assign({}, config[0])).toEqual({
+      name: 'team1',
+      executions: [
+        {
+          schedule: { hour: 10, minute: 0, weekdays: ['mon', 'wed'] },
+          repositories: [
+            { host: 'github', id: 'talkdesk/team1-repo1' },
+            { host: 'github', id: 'talkdesk/team1-repo2' },
+          ],
+          notifications: [
+            { channel: 'slack', address: '#team1' },
+            { channel: 'slack', address: '#team2' },
+          ],
+        },
+      ],
+    })
+  })
+
+  describe("when the configuration doesn't match the schema", () => {
+    it('raises an error', () => {
+      const invalidInput = { test: [] }
+
+      expect(() => parse(invalidInput)).toThrowError(InvalidConfigurationError)
+    })
+  })
+
+  describe('when the schedule hour is greater than 23', () => {
+    it('raises an error', () => {
+      const invalidInput = {
+        team1: {
+          executions: [
+            {
+              schedule: { hour: 24, minute: 30, weekdays: [] },
+              repositories: [],
+              notifications: [],
+            },
+          ],
+        },
+      }
+
+      expect(() => parse(invalidInput)).toThrowError(/hour: must have a maximum value of 23/)
+    })
+  })
+
+  describe('when the schedule hour is smaller than 0', () => {
+    it('raises an error', () => {
+      const invalidInput = {
+        team1: {
+          executions: [
+            {
+              schedule: { hour: -1, minute: 30, weekdays: [] },
+              repositories: [],
+              notifications: [],
+            },
+          ],
+        },
+      }
+
+      expect(() => parse(invalidInput)).toThrowError(/hour: must have a minimum value of 0/)
+    })
+  })
+
+  describe('when the schedule minute is smaller than 0', () => {
+    it('raises an error', () => {
+      const invalidInput = {
+        teams1: {
+          executions: [
+            {
+              schedule: { hour: 23, minute: -1, weekdays: [] },
+              repositories: [],
+              notifications: [],
+            },
+          ],
+        },
+      }
+
+      expect(() => parse(invalidInput)).toThrowError(/minute: must have a minimum value of 0/)
+    })
+  })
+
+  describe('when the schedule minute is greater than 59', () => {
+    it('raises an error', () => {
+      const invalidInput = {
+        team1: {
+          executions: [
+            {
+              schedule: { hour: 23, minute: 60, weekdays: [] },
+              repositories: [],
+              notifications: [],
+            },
+          ],
+        },
+      }
+
+      expect(() => parse(invalidInput)).toThrowError(/minute: must have a maximum value of 59/)
+    })
+  })
+
+  describe('when the schedule has an invalid weekday', () => {
+    it('raises an error', () => {
+      const invalidInput = {
+        team1: {
+          executions: [
+            {
+              schedule: { hour: 23, minute: 0, weekdays: ['xxxx'] },
+              repositories: [],
+              notifications: [],
+            },
+          ],
+        },
+      }
+
+      expect(() => parse(invalidInput)).toThrowError(/weekdays\[0\]: is not one of enum/)
+    })
+  })
+
+  describe('when the repository has an invalid host', () => {
+    it('raises an error', () => {
+      const invalidInput = {
+        team1: {
+          executions: [
+            {
+              schedule: { hour: 23, minute: 0, weekdays: [] },
+              repositories: [{ host: 'invalid', id: 'repo1' }],
+              notifications: [],
+            },
+          ],
+        },
+      }
+
+      expect(() => parse(invalidInput)).toThrowError(/host: is not one of enum values/)
+    })
+  })
+
+  describe('when the notification has an invalid channel', () => {
+    it('raises an error', () => {
+      const invalidInput = {
+        team1: {
+          executions: [
+            {
+              schedule: { hour: 23, minute: 0, weekdays: [] },
+              repositories: [],
+              notifications: [{ channel: 'invalid', address: '#team' }],
+            },
+          ],
+        },
+      }
+
+      expect(() => parse(invalidInput)).toThrowError(/channel: is not one of enum values/)
+    })
+  })
+})

--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,7 @@
     "interface-name": false,
     "object-literal-sort-keys": false,
     "no-console": false,
+    "max-classes-per-file": [false],
     "file-name-casing": [
       true,
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2293,6 +2293,11 @@ json5@2.x, json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
+jsonschema@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.4.tgz#a46bac5d3506a254465bc548876e267c6d0d6464"
+  integrity sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"


### PR DESCRIPTION
This commit introduces the configuration parser which validates an input
configuration datastructure against a pre-defined schema and if
successful parses it.

The goal here is to have the rest of the application dealing with a
known configuration datastructured (enforce by the Typescript's type
checker).