### PR TITLE
fix: correctly identify excluded labels

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -82,12 +82,12 @@ module.exports = function server () {
     }
 
     const headers = [ messages.PR_LIST_HEADER, '\n' ]
-    const excludeLabelsConfigured = !!excludeLabels.length
+    const excludeLabelsConfigured = !!excludeLabels.size
 
     let includedPrs = data
     if (excludeLabelsConfigured) {
       includedPrs = data.filter((pr) => {
-        const hasExcludedLabel = pr.labels.reduce((acc, label) => acc || excludeLabels.has(label), false)
+        const hasExcludedLabel = pr.labels.reduce((acc, label) => acc || excludeLabels.has(label.name), false)
         return !hasExcludedLabel
       })
     }


### PR DESCRIPTION
Currently the excluded labels are not being correctly recognised. This PR fixes how the excluded labels are checked:
- `excludeLabels` is a Set and `.size` should be used instead of `.length`
- when checking if the labels of a PR are in the `excludeLabels` Set, the `name` property should be used as the value rather than the whole object